### PR TITLE
Added notebook for viewing AIS data

### DIFF
--- a/Notebook/Viewing_AIS.ipynb
+++ b/Notebook/Viewing_AIS.ipynb
@@ -1,0 +1,172 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Viewing AIS data\n",
+    "\n",
+    "This notebook is work in progress that declares a Panel dashboard to visualize AIS data. All available AIS data is visualized with datashader and a `DatetimeInput` panel widget allows display of vessel locations at a chosen time.\n",
+    "\n",
+    "Not yet optimized and filtering vessels can take a few moments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import panel as pn\n",
+    "import datetime as dt\n",
+    "import holoviews as hv\n",
+    "from holoviews.operation.datashader import rasterize\n",
+    "hv.extension('bokeh')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zone1 = pd.read_csv('./data/AIS_2017_01_Zone01.csv', parse_dates=[1])\n",
+    "zone2 = pd.read_csv('./data/AIS_2017_01_Zone02.csv', parse_dates=[1])\n",
+    "zone3 = pd.read_csv('./data/AIS_2017_01_Zone03.csv', parse_dates=[1])\n",
+    "zones = pd.concat([zone1,zone2, zone3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zones.head() # Dataframe structure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vessels = {name:df.drop_duplicates().sort_values(by='BaseDateTime').set_index('BaseDateTime') for name,df in zones.groupby('VesselName')}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE! Some of the data is missing (presumably an unknown vessel)\n",
+    "# Consider substituting MMSI for VesselName if missing\n",
+    "zone1.iloc[8859]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Expected Latitude range %.3f to %.3f\"% (min(zones['LAT']), max(zones['LAT'])))\n",
+    "print(\"Expected Longitude range %.3f to %.3f \" % (min(zones['LON']), max(zones['LON'])))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eastings, northings = zip(*[hv.util.transform.lon_lat_to_easting_northing(lon, lat) for lon, lat \n",
+    "                          in zip(zones['LON'], zones['LAT'])])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt_input = pn.widgets.DatetimeInput(name='Datetime', value=zones['BaseDateTime'].min())\n",
+    "dt_input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def vessel_at_time(vessel_name, time, vessels):\n",
+    "    df = vessels[vessel_name].drop_duplicates()\n",
+    "    if time < df.index[0]:\n",
+    "        return None # Query before first value\n",
+    "    if time > df.index[-1]:\n",
+    "        return None # Query after last value\n",
+    "    try:\n",
+    "        idx = df.index.get_loc(time, method='nearest')\n",
+    "        return df.iloc[idx]\n",
+    "    except:\n",
+    "        return None\n",
+    "\n",
+    "def mark_vessels(value):\n",
+    "    records = []\n",
+    "    empty = {'easting':0., 'northing':-7.081154551613623e-10, 'name':'', 'callsign':''}\n",
+    "    for vessel in vessels.keys():\n",
+    "        match = vessel_at_time(vessel, value, vessels)\n",
+    "        if match is not None:\n",
+    "            easting, northing = hv.util.transform.lon_lat_to_easting_northing(match['LON'], match['LAT'])\n",
+    "            records.append({'easting':easting, 'northing':northing, \n",
+    "                            'name':match['VesselName'], 'callsign':match['CallSign']})\n",
+    "    markers = pd.DataFrame(records if len(records) != 0 else [empty]) \n",
+    "    alpha = 1 if len(records) else 0\n",
+    "    return hv.Points(markers, ['easting', 'northing'], ['name','callsign']).opts(color='white', size=4, \n",
+    "                                                                                 marker='triangle', alpha=alpha)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "points = rasterize(hv.Points(pd.DataFrame({'northing':northings, \n",
+    "                                           'easting':eastings}), ['easting', 'northing']))\n",
+    "tiles = hv.element.tiles.ESRI().redim(x='easting', y='northing')\n",
+    "\n",
+    "overlay = (tiles * points.opts(cmap='fire', width=900, height=500, cnorm='eq_hist', alpha=0.5) \n",
+    " * hv.DynamicMap(mark_vessels, streams=[dt_input.param.value]))\n",
+    "message = (\"Example times to compare: 2017-01-17 00:00:00 vs 2017-01-18 00:00:00 with \"\n",
+    "           \"white triangles marking vessel locations. Unoptimized first cut: filtering updates can take a few moments.\")\n",
+    "pn.Column('# AIS Data (Work in progress)', message, dt_input, overlay).servable()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Work in Progress.

This notebook visualizing the combined latitude and longitude AIS data for three zones using datashader and offers a `DatetimeInput` widget to mark vessel locations at the chosen time.

## Current features (first cut):

* Dynamic zooming of all the AIS data using datashader:

<img width=70% src="https://user-images.githubusercontent.com/890576/102947772-b43c6f80-4489-11eb-9d44-87fe2d4df1d6.gif"></img>

* Filtering by time to update vessel locations

<img width=70% src="https://user-images.githubusercontent.com/890576/102947676-7d665980-4489-11eb-81d8-243b467dde33.gif"></img>

This is the very first cut and my immediate next steps are to:

* Integrate satellite data (ideas: rasterize satellite tracks, mark satellites at chosen time)
* Implement UI improvements
* Optimization (e.g speed up loading of data, speed up filtering step)