### PR TITLE
Added notebook viewing anomalous AIS ping deltas

### DIFF
--- a/Viewing_AIS_Gaps.ipynb
+++ b/Viewing_AIS_Gaps.ipynb
@@ -149,7 +149,7 @@
    "source": [
     "### Datashade all AIS data as points and unusually delayed pings as segments\n",
     "\n",
-    "Note that when zooming in around Portland, you can see segments crossing land. These mark vessels that generated an AIS ping while out to see and did not generate another AIS ping until inland."
+    "Note that when zooming in around Portland, you can see segments crossing land. These mark vessels that generated an AIS ping while out to sea and did not generate another AIS ping until inland."
    ]
   },
   {


### PR DESCRIPTION
This PR adds the Viewing_AIS_Gaps notebook (addressing a TODO item in https://github.com/att-vault/vault/issues/12). This notebook visualizes anomalously large temporal ping deltas (by default, >20 standard deviations from the mean delta) as datashaded segments:

![image](https://user-images.githubusercontent.com/890576/103799201-65a5de00-5010-11eb-8ccf-08206740901a.png)
