### PR TITLE
Improved satellite selection in Hit Dashboard notebook

### DIFF
--- a/Hit_Dashboard.ipynb
+++ b/Hit_Dashboard.ipynb
@@ -8,6 +8,7 @@
    },
    "outputs": [],
    "source": [
+    "import re\n",
     "import os\n",
     "import warnings\n",
     "import pandas as pd\n",
@@ -291,7 +292,7 @@
    "source": [
     "### Declaring panel widgets\n",
     "\n",
-    "Satellite selector (autocomplete input widget):"
+    "Satellite selector widgets:"
    ]
   },
   {
@@ -300,10 +301,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "selector = pn.widgets.AutocompleteInput(\n",
-    "    name='Satellite', options=list(norad_names.keys()),\n",
-    "    placeholder='Satellite name')\n",
-    "selector.value = 'International Space Station (ISS [first element Zarya])'"
+    "satellites = list(norad_names.keys())\n",
+    "constellations = sorted(list(set([re.sub(r'[ -].*', '', str(s)) for s in satellites])))\n",
+    "constellation = pn.widgets.Select(options=constellations, name=\"Constellation\")\n",
+    "constellation.value = 'International'\n",
+    "satellite = pn.widgets.Select(options=[s for s in satellites \n",
+    "                                       if re.match(constellation.value, str(s))], name=\"Satellite\")\n",
+    "\n",
+    "@pn.depends(constellation.param.value, watch=True)\n",
+    "def update_satellite_options(constellation):\n",
+    "    satellite.options = [s for s in satellites if re.match(constellation, str(s))]"
    ]
   },
   {
@@ -377,7 +384,7 @@
    "source": [
     "tiles = hv.element.tiles.ESRI().redim(x='easting', y='northing')\n",
     "hits_dmap = hv.DynamicMap(rasterize_hits, \n",
-    "                          streams=[selector.param.value,  start_date.param.value, end_date.param.value,\n",
+    "                          streams=[satellite.param.value,  start_date.param.value, end_date.param.value,\n",
     "                                   start_time.param.value, end_time.param.value,\n",
     "                                   full_range.param.value,\n",
     "                                    hv.streams.PlotSize(width=700, height=500),  hv.streams.RangeXY()],\n",
@@ -401,7 +408,8 @@
    "source": [
     "pn.Column(pn.Column(full_range, \n",
     "                    pn.Row(start_date, end_date),\n",
-    "                    pn.Row(start_time, end_time)), selector, tiles * hits_dmap).servable()"
+    "                    pn.Row(start_time, end_time)), \n",
+    "                    pn.Row(constellation, satellite), tiles * hits_dmap).servable()"
    ]
   }
  ],


### PR DESCRIPTION
Addressing another TODO item in https://github.com/att-vault/vault/issues/12, this PR adds an improved satellite selector for the Hit dashboard:

![improved_selector](https://user-images.githubusercontent.com/890576/103841855-2bf9c500-505a-11eb-863d-197a81610d53.gif)
