### PR TITLE
Added vessel metadata and filtered markers outside Web Mercator

### DIFF
--- a/Hit_Dashboard.ipynb
+++ b/Hit_Dashboard.ipynb
@@ -157,7 +157,7 @@
    "outputs": [],
    "source": [
     "vessel_categories = pd.read_csv(\"./metadata/AIS_categories.csv\")\n",
-    "vessel_df = pd.read_csv(\"./data/vault-data-corpus/vessel data/ConsolidatedAIS/Vessel.csv\")\n",
+    "vessel_df = pd.read_csv(\"./data/vessel data/ConsolidatedAIS/Vessel.csv\")\n",
     "vessel_info_dict = {row['mmsi_id']:{'vessel_name':row['vessel_name'], 'length':row['length'], \n",
     "'vessel_type': vessel_categories[vessel_categories['num']==(0 if np.isnan(row['vessel_type']) \n",
     "                                 else int(row['vessel_type']))].iloc[0]['desc'],\n",


### PR DESCRIPTION
Adds vessel type metadata and ensures vessel markers fit within the Web Mercator projection:
 
![image](https://user-images.githubusercontent.com/890576/103903033-f50aca00-50c0-11eb-8d24-8f1fe2d1d6e4.png)
