### PR TITLE
Datashading over SOG in Viewing AIS notebook

### DIFF
--- a/Viewing_AIS.ipynb
+++ b/Viewing_AIS.ipynb
@@ -22,6 +22,7 @@
     "import holoviews as hv\n",
     "import colorcet as cc\n",
     "import param\n",
+    "import datashader as ds\n",
     "from holoviews.util.transform import lon_lat_to_easting_northing as ll2en\n",
     "from holoviews.operation.datashader import rasterize, dynspread\n",
     "hv.extension('bokeh')"
@@ -411,8 +412,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "points = dynspread(rasterize(hv.Points(zones, ['x','y']).redim.range(**bounds))).opts(opts)\n",
-    "\n",
+    "points = dynspread(rasterize(hv.Points(zones, ['x','y'], ['SOG']).redim.range(**bounds), \n",
+    "                             aggregator=ds.mean('SOG'))).opts(opts)\n",
     "title = \"# AIS vessel locations\"\n",
     "\n",
     "message = (\"Select a time covered by this dataset and press return to see vessel locations at that time \"\n",


### PR DESCRIPTION
Small change to Viewing AIS notebook to aggregate over SOG (speed over ground):

![image](https://user-images.githubusercontent.com/890576/103913854-a49a6900-50ce-11eb-86ac-40f3429fc79c.png)

Addresses a TODO item in https://github.com/att-vault/vault/issues/12