### PR TITLE
Fixed typo in download instructions

### DIFF
--- a/Download_Data.md
+++ b/Download_Data.md
@@ -7,7 +7,7 @@ There are two S3 buckets available.
 |    |  S3 URI | size |
 |----|----|----|
 | [Full dataset](http://vault-data-corpus.s3-website.us-east-2.amazonaws.com/) | s3://vault-data-corpus | 66 gb |
-| [Minimal dataset](http://vault-data-minimal.s3-website.us-east-2.amazonaws.com/) | s3://vault-data-corpus | 25 gb |
+| [Minimal dataset](http://vault-data-minimal.s3-website.us-east-2.amazonaws.com/) | s3://vault-data-minimal | 55 gb |
 
 The minimal dataset is all that is required for us to run the "Hit Finder" solution and dashboard, as well as some visualization exploration notebooks.
 

--- a/Download_Data.md
+++ b/Download_Data.md
@@ -15,7 +15,7 @@ The full dataset contains input data for some of the ML and ETL notebooks.
 
 # Extracting the data
 
-You can copy the files from , putting them in `/data` on your own system (local or cloud) if you have access to `/`, or else put the data somewhere in your writable directories and update the `./data` symlink to point to its location. E.g.:
+You will need to copy the files from S3 into your local machine or cloud host, putting them in `/data` if you have access to `/`, or else put the data somewhere in your writable directories and update the `./data` symlink to point to its location. E.g.:
 
 ```
 > cd /data


### PR DESCRIPTION
There was some missing text in the description of how to download the data; up to @pzwang to decide whether to merge.