### PR TITLE
Set up caching for panel app

### DIFF
--- a/Viewing_AIS.ipynb
+++ b/Viewing_AIS.ipynb
@@ -31,28 +31,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Data has been provided for four [UTM zones](https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system#UTM_zone) (1, 2, 3, and 10), with vessels identified by their [Maritime Mobile Service Identity](https://en.wikipedia.org/wiki/Maritime_Mobile_Service_Identity) numbers.\n",
-    "\n",
-    "Here we will use [pandas](https://pandas.pydata.org) to load 2017 data from zones 1-3 and 2014 data from zone 10:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "zone1 = pd.read_csv('./data/vessel data/AIS/AIS_2017_01_Zone01.csv', parse_dates=[1])\n",
-    "zone2 = pd.read_csv('./data/vessel data/AIS/AIS_2017_01_Zone02.csv', parse_dates=[1])\n",
-    "zone3 = pd.read_csv('./data/vessel data/AIS/AIS_2017_01_Zone03.csv', parse_dates=[1])\n",
-    "zone10= pd.read_csv('./data/vessel data/Cleaned AIS/Zone10_2014_01/Broadcast.csv', parse_dates=[1])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here the zone 1-3 data was provided directly as CSVs, while the zone 10 data was created from the provided GDB files using `ogr2ogr`. `ogr2ogr` produces several CSVs per GDB file, and here we focus only on Broadcast.csv. The column names for the zone 10 data are slightly different from the others, so we will first map from those to the format from the original csvs:"
+    "Data has been provided for four [UTM zones](https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system#UTM_zone) (1, 2, 3, and 10), with vessels identified by their [Maritime Mobile Service Identity](https://en.wikipedia.org/wiki/Maritime_Mobile_Service_Identity) numbers. Data for zones 1-3 was provided as CSVs that can be loaded directly in Python, while the zone 10 data was converted to CSV using `ogr2ogr` from the provided GDB files. `ogr2ogr` produces several CSVs per GDB file, and here we focus only on Broadcast.csv. The column names in Broadcast.csv are slightly different from zone1-3 files, so we'll set up a mapping between the column names:"
    ]
   },
   {
@@ -62,16 +41,14 @@
    "outputs": [],
    "source": [
     "columnmap = dict(mmsi_id='MMSI', date_time='BaseDateTime', lat='LAT', lon='LON', speed_over_ground='SOG', \n",
-    "                 course_over_ground='COG', heading='Heading', status='Status')\n",
-    "\n",
-    "zone10.columns = [columnmap.get(c,c) for c in zone10.columns]"
+    "                 course_over_ground='COG', heading='Heading', status='Status')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The AIS files include a variety of data and metadata values about each reported AIS broadcast. As we can see by looking at the first few rows of data, some of these values indicate the current state (e.g. LAT, LON, SOG, COG, Heading at the given time), while the others indicate metadata about the vessel (VesselName, CallSign, etc.):"
+    "Now we'll write a function that uses [pandas](https://pandas.pydata.org) to load 2017 data from zones 1-3 and 2014 data from zone 10:"
    ]
   },
   {
@@ -80,8 +57,38 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "zones = pd.concat([zone1,zone2, zone3, zone10])\n",
+    "def load_data():\n",
+    "    print(\"Loading data...\")\n",
+    "    zone1 = pd.read_csv('./data/vessel data/AIS/AIS_2017_01_Zone01.csv', parse_dates=[1])\n",
+    "    zone2 = pd.read_csv('./data/vessel data/AIS/AIS_2017_01_Zone02.csv', parse_dates=[1])\n",
+    "    zone3 = pd.read_csv('./data/vessel data/AIS/AIS_2017_01_Zone03.csv', parse_dates=[1])\n",
+    "    zone10= pd.read_csv('./data/vessel data/Cleaned AIS/Zone10_2014_01/Broadcast.csv', parse_dates=[1])\n",
+    "    zone10.columns = [columnmap.get(c,c) for c in zone10.columns]\n",
+    "    return pd.concat([zone1,zone2, zone3, zone10])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then load the files, using the `pn.state.as_cached` function to cache the data to ensure that only the first visitor to our app (below) has to load the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zones = pn.state.as_cached('zones', load_data)\n",
     "zones.tail()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The AIS files include a variety of data and metadata values about each reported AIS broadcast. As we can see by looking at the first few rows of data, some of these values indicate the current state (e.g. LAT, LON, SOG, COG, Heading at the given time), while the others indicate metadata about the vessel (VesselName, CallSign, etc.):"
    ]
   },
   {
@@ -144,7 +151,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To put this data in context, let's plot it on a map. We'll use a public map tile source in Web Mercator coordinates, so we'll first project the LON,LAT coorinates to easting,northing values:"
+    "To put this data in context, let's plot it on a map. We'll use a public map tile source in Web Mercator coordinates, so we'll first project the LON,LAT coorinates to easting,northing values, caching the results for later use:"
    ]
   },
   {
@@ -154,7 +161,12 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "zones.loc[:,'x'], zones.loc[:,'y'] = ll2en(zones.LON,zones.LAT)"
+    "def project_data():\n",
+    "   print(\"Projecting data...\")\n",
+    "   zones.loc[:,'x'], zones.loc[:,'y'] = ll2en(zones.LON,zones.LAT)\n",
+    "   return zones\n",
+    "\n",
+    "zones = pn.state.as_cached('zones2', project_data)"
    ]
   },
   {


### PR DESCRIPTION
Makes the app from `panel serve Viewing_AIS.ipynb` load and project the data only the first time it is visited, caching the resulting dataframe in memory for subsequent visitors. Seems to work, though the page load time still seems fairly slow even after caching. Plus I may be confused, but the throttling for zooming seems worse for the app than for the Jupyter version.